### PR TITLE
Switch to kt-paperclip

### DIFF
--- a/paperclip-tus.gemspec
+++ b/paperclip-tus.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_runtime_dependency 'paperclip', '>= 6.0'
+  spec.add_runtime_dependency 'kt-paperclip', '>= 6.2'
   spec.add_runtime_dependency 'tus-server', '~> 0.10'
 end


### PR DESCRIPTION
`paperclip` is discontinued. Switch to an active fork `kt-paperclip`.